### PR TITLE
Add instruction to install from elementary flatpak  to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ If you like what i make, it would really be nice to have someone buy me a coffee
 
 ## Installation
 
-## Build using flatpak
+
+### Install from elementary flatpak remote
+
+```
+flatpak remote-add --if-not-exists --system appcenter https://flatpak.elementary.io/repo.flatpakrepo
+flatpak install com.github.hezral.clips
+```
+
+### Build using flatpak
 * requires that you have flatpak-builder installed
 * flatpak enabled
 * flathub remote enabled


### PR DESCRIPTION
At a quick glance could not figure out how to install this app. Took a look at #38 and saw it was quite easy actually, no manual build required, and figured out this should live in the readme for future potential users.